### PR TITLE
Adagrams Game!

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,22 @@ $ npm run coverage
 
 This is shorthand for the command `open coverage/lcov-report/index.html` and will open the coverage report in your default web browser.
 
-### Driver Code
-We have provided some driver code for your Adagrams game in the files `wave-1-game.rb`, `wave-2-game.rb`, `wave-3-game.rb`, and `wave-4-game.rb`. Running `$ ruby wave-1-game.rb` will begin a command-line game that uses your Adagrams code. The boilerplate code will break the first time you run it: working through the waves specified below should create a running version of the game. **Implementing code to make this game run is not a substitute for making the tests pass**. It is simply there for you and your pair to reference how the Game may run during each wave, to have better perspective of what your program can do, and to get some practice reading other peoples' code. We fully expect you to create the specified functions to specification and making the tests pass.
+### Adagrams Game
+In addition to the provided unit tests we have provided a game application which makes use of the Adagrams code that you will implement. You can play the game as you implement each wave of the project and verify that game functionality begins to work, in addition to passing unit tests.
+
+You can start the game application with the following command:
+
+```bash
+$ npm run game
+```
+
+This will start the Adagrams prompt, and you can start a new game by typing `start` (or `start <num>` for a game with multiple players).
+
+Once the game has started each player is prompted to play anagrams from the displayed letter bank until their turn completes. At the end of each round the player who played the best word (according to the logic you will implement in wave 4) is awarded points based on that word. Once all rounds are completed the game announced who won with the point total for that player.
+
+**NOTE**: If you would like to play the full version of the game before your implementation is complete you can check out the `solution/obfuscated` branch and follow the steps above.
+
+The game is fairly rudimentary and has a few bugs remaining, such as needing to type 'exit' to complete your turn. If you've completed all of the waves for this project and wish to continue working on terminal JavaScript code, feel free to ask your instructors for suggestions on bug fixes or improvements to make for the game code.
 
 ### Project Structure
 This repository has a baseline structure for the project which includes several files. You will only need to modify one of them:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install
 Similar to `bundle install` in Ruby projects, this makes the npm package manager download and install any dependencies for the project (such as Jest).
 
 ### Tests
-We have provided unit tests for you to run. A complete project will pass all provided tests.
+We have provided unit tests for you to run. A complete project will pass all provided tests in the `specs/adagrams.spec.js` file. The other specs are for game logic that is already implemented and they may pass or fail depending upon the state of your code, however you should focus on just the tests in `specs/adagrams.spec.js`.
 
 To run the tests, in the command line, navigate to the project root and then run:
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,7 +16,10 @@ const presets = [
 const plugins = [
   ["module-resolver", {
     "root": ["./src"]
-  }]
+  }],
+  ["@babel/plugin-proposal-class-properties", {
+    "loose": true
+  }],
 ];
 
 module.exports = { presets, plugins };

--- a/package-lock.json
+++ b/package-lock.json
@@ -329,6 +329,20 @@
         "@babel/plugin-syntax-async-generators": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
+      "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
@@ -374,6 +388,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
+      "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -822,8 +822,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1111,6 +1110,23 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-jest": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
@@ -1175,7 +1191,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1184,8 +1199,7 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },
@@ -1536,6 +1550,19 @@
         }
       }
     },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
+    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -1573,8 +1600,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1646,8 +1672,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1888,8 +1913,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.0",
@@ -1966,6 +1990,11 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -2190,6 +2219,15 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "filename-regex": {
@@ -3005,7 +3043,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3115,6 +3152,11 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3130,6 +3172,59 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "inquirer": {
+      "version": "0.11.0",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz",
+      "integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^1.0.1",
+        "figures": "^1.3.5",
+        "lodash": "^3.3.1",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -4671,8 +4766,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -4686,6 +4780,22 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "requires": {
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        }
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4853,6 +4963,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
@@ -4890,6 +5005,11 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node-localstorage": {
+      "version": "0.6.0",
+      "resolved": "http://registry.npmjs.org/node-localstorage/-/node-localstorage-0.6.0.tgz",
+      "integrity": "sha1-RaBgHGky395mRKIzYfG+Fzx1068="
     },
     "node-notifier": {
       "version": "5.3.0",
@@ -4945,8 +5065,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.0.9",
@@ -4963,8 +5082,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5045,10 +5163,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "optimist": {
       "version": "0.6.1",
@@ -5459,6 +5581,26 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        }
+      }
+    },
     "realpath-native": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
@@ -5677,6 +5819,15 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -5697,6 +5848,19 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
       "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
       "dev": true
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "requires": {
+        "once": "^1.3.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -6129,7 +6293,6 @@
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -6273,6 +6436,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmpl": {
       "version": "1.0.4",
@@ -6586,6 +6754,52 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vorpal": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/vorpal/-/vorpal-1.12.0.tgz",
+      "integrity": "sha1-S+eypOSPj8/JzzZIxBnTEcUiFZ0=",
+      "requires": {
+        "babel-polyfill": "^6.3.14",
+        "chalk": "^1.1.0",
+        "in-publish": "^2.0.0",
+        "inquirer": "0.11.0",
+        "lodash": "^4.5.1",
+        "log-update": "^1.0.2",
+        "minimist": "^1.2.0",
+        "node-localstorage": "^0.6.0",
+        "strip-ansi": "^3.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "w3c-hr-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
@@ -6679,7 +6893,6 @@
       "version": "2.1.0",
       "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -6689,7 +6902,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6698,7 +6910,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6710,8 +6921,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,21 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/node": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.0.0.tgz",
+      "integrity": "sha512-mKbN8Bb1TzH9YnKMWMhBRX+o5MVJHtUSalNcsiGa4FRgVfY7ozqkbttuIDWqeXxZ3rwI9ZqmCUr9XsPV2VYlSw==",
+      "dev": true,
+      "requires": {
+        "@babel/polyfill": "^7.0.0",
+        "@babel/register": "^7.0.0",
+        "commander": "^2.8.1",
+        "fs-readdir-recursive": "^1.0.0",
+        "lodash": "^4.17.10",
+        "output-file-sync": "^2.0.0",
+        "v8flags": "^3.1.1"
+      }
+    },
     "@babel/parser": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.5.tgz",
@@ -660,6 +675,24 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.11.1"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.5.tgz",
@@ -707,6 +740,45 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.3.0"
+      }
+    },
+    "@babel/register": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
+      "integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "find-cache-dir": "^1.0.0",
+        "home-or-tmp": "^3.0.0",
+        "lodash": "^4.17.10",
+        "mkdirp": "^0.5.1",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.9"
+      },
+      "dependencies": {
+        "home-or-tmp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+          "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "@babel/template": {
@@ -1642,6 +1714,12 @@
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -2277,6 +2355,17 @@
       "requires": {
         "json5": "^0.5.1",
         "path-exists": "^3.0.0"
+      }
+    },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-up": {
@@ -3099,6 +3188,15 @@
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -4816,6 +4914,23 @@
         "yallist": "^2.1.2"
       }
     },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -5010,6 +5125,12 @@
       "version": "0.6.0",
       "resolved": "http://registry.npmjs.org/node-localstorage/-/node-localstorage-0.6.0.tgz",
       "integrity": "sha1-RaBgHGky395mRKIzYfG+Fzx1068="
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
     },
     "node-notifier": {
       "version": "5.3.0",
@@ -5306,6 +5427,12 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -5385,6 +5512,15 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pirates": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+      "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pkg-dir": {
@@ -6732,6 +6868,15 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
+    },
+    "v8flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+      "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "coverage": "open coverage/lcov-report/index.html",
-    "game": "babel src/game.js"
+    "game": "babel-node src/game.js"
   },
   "repository": {
     "type": "git",
@@ -22,6 +22,7 @@
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.5",
     "@babel/node": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.1.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "babel-plugin-module-resolver": "^3.1.1",
     "jest": "^23.6.0",
     "regenerator-runtime": "^0.12.1"
+  },
+  "dependencies": {
+    "vorpal": "^1.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "coverage": "open coverage/lcov-report/index.html"
+    "coverage": "open coverage/lcov-report/index.html",
+    "game": "babel src/game.js"
   },
   "repository": {
     "type": "git",
@@ -20,6 +21,7 @@
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.5",
+    "@babel/node": "^7.0.0",
     "@babel/preset-env": "^7.1.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -40,4 +40,13 @@ describe('Game Model', () => {
       });
     });
   });
+
+
+  describe('.nextRound', () => {
+    it('is defined', () => {
+      const model = new Model(config);
+
+      expect(model.nextRound).toBeDefined();
+    });
+  });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -100,6 +100,19 @@ describe('Game Model', () => {
       expect(model.currentPlayer).toBe(0);
     });
 
+    it('initializes the round play history for first player', () => {
+      const model = new Model(config);
+
+      model.nextRound();
+
+      config.players.forEach((player) => {
+        const roundPlays = model.plays[player][model.round - 1];
+
+        expect(roundPlays).toBeInstanceOf(Array);
+        expect(roundPlays).toHaveLength(0);
+      });
+    });
+
     it('draws a new hand of letters', () => {
       const model = new Model(config);
 

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -126,6 +126,21 @@ describe('Game Model', () => {
     });
   });
 
+  describe('.nextTurn', () => {
+    const getModel = () => {
+      const model = new Model(config);
+      model.nextRound();
+
+      return model;
+    };
+
+    it('is defined', () => {
+      const model = getModel();
+
+      expect(model.nextTurn).toBeDefined();
+    });
+  });
+
   describe('.playWord', () => {
     const getModel = () => {
       const model = new Model(config);

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -134,6 +134,10 @@ describe('Game Model', () => {
       return model;
     };
 
+    const getPlays = (model, player, round) => {
+      return [...(model.plays[player][round - 1] || [])];
+    };
+
     it('is defined', () => {
       const model = getModel();
 
@@ -152,6 +156,20 @@ describe('Game Model', () => {
 
         expect(model.playWord(word)).toBe(score);
       });
+
+      it('adds word to plays history for current player', () => {
+        const model = getModel();
+        const player = model.currentPlayerName();
+        const origPlays = getPlays(model, player, model.round);
+
+        const word1 = getWord(model);
+        model.playWord(word1);
+        expect(getPlays(model, player, model.round)).toEqual([...origPlays, word1]);
+
+        const word2 = getWord(model);
+        model.playWord(word2);
+        expect(getPlays(model, player, model.round)).toEqual([...origPlays, word1, word2]);
+      });
     });
 
     describe('for invalid words', () => {
@@ -169,6 +187,16 @@ describe('Game Model', () => {
         expect(model.playWord(word)).toBe(null);
         expect(model.playWord('123')).toBe(null);
         expect(model.playWord('')).toBe(null);
+      });
+
+      it('does not add word to history', () => {
+        const model = getModel();
+        const word = getWord(model);
+        const origPlays = {...model.plays};
+
+        model.playWord(word);
+
+        expect(model.plays).toEqual(origPlays);
       });
     });
   });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -48,5 +48,14 @@ describe('Game Model', () => {
 
       expect(model.nextRound).toBeDefined();
     });
+
+    it('increments the round number', () => {
+      const model = new Model(config);
+      const roundBefore = model.round;
+
+      model.nextRound();
+
+      expect(model.round).toBe(roundBefore + 1);
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -9,5 +9,11 @@ describe('Game Model', () => {
 
       expect(model).toBeInstanceOf(Model);
     });
+
+    it('requires a config parameter', () => {
+      expect(() => {
+        const model = new Model();
+      }).toThrow(/config/);
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -57,5 +57,13 @@ describe('Game Model', () => {
 
       expect(model.round).toBe(roundBefore + 1);
     });
+
+    it('initializes the current player number to first player', () => {
+      const model = new Model(config);
+
+      model.nextRound();
+
+      expect(model.currentPlayer).toBe(0);
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -54,6 +54,27 @@ describe('Game Model', () => {
     });
   });
 
+  describe('.currentPlayerName()', () => {
+    it('is defined', () => {
+      const model = new Model(config);
+
+      expect(model.currentPlayerName).toBeDefined();
+    });
+
+    it('returns the name of the current player when game is on-going', () => {
+      const model = new Model(config);
+
+      model.nextRound();
+
+      expect(model.currentPlayerName()).toEqual(model.config.players[0]);
+    });
+
+    it('returns null when the game is not on-going', () => {
+      const model = new Model(config);
+
+      expect(model.currentPlayerName()).toBe(null);
+    });
+  });
 
   describe('.nextRound', () => {
     it('is defined', () => {

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -35,6 +35,12 @@ describe('Game Model', () => {
       expect(model.currentPlayer).toBe(null);
     });
 
+    it('initializes the letter bank to null', () => {
+      const model = new Model(config);
+
+      expect(model.letterBank).toBe(null);
+    });
+
     it('initializes the plays history', () => {
       const model = new Model(config);
 

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -119,5 +119,23 @@ describe('Game Model', () => {
         expect(model.playWord(word)).toBe(score);
       });
     });
+
+    describe('for invalid words', () => {
+      const getWord = (model) => {
+        const letter = model.letterBank[0];
+        return letter.repeat(model.letterBank.filter((l) => {
+          return l === letter;
+        }).length + 1);
+      };
+
+      it('it returns null', () => {
+        const model = getModel();
+        const word = getWord(model);
+
+        expect(model.playWord(word)).toBe(null);
+        expect(model.playWord('123')).toBe(null);
+        expect(model.playWord('')).toBe(null);
+      });
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -1,7 +1,14 @@
 import Model from 'game/model';
 
 describe('Game Model', () => {
-  const config = {};
+  const config = {
+    players: [
+      'Player A',
+      'Player B',
+    ],
+    rounds: 3,
+    time: 60, // Seconds
+  };
 
   describe('constructor', () => {
     it('creates a new Model instance', () => {

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -29,6 +29,12 @@ describe('Game Model', () => {
       expect(model.round).toBe(0);
     });
 
+    it('initializes the current player to null', () => {
+      const model = new Model(config);
+
+      expect(model.currentPlayer).toBe(null);
+    });
+
     it('initializes the plays history', () => {
       const model = new Model(config);
 

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -297,6 +297,14 @@ describe('Game Model', () => {
         model.playWord(word2);
         expect(getPlays(model, player, model.round)).toEqual([...origPlays, word1, word2]);
       });
+
+      it('validates word case-insensitively', () => {
+        const model = getModel();
+        const word = getWord(model);
+        const score = Adagrams.scoreWord(word);
+
+        expect(model.playWord(word.toLowerCase())).toBe(score);
+      });
     });
 
     describe('for invalid words', () => {

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -150,6 +150,30 @@ describe('Game Model', () => {
       model.nextTurn();
       expect(model.currentPlayer).toBe(origPlayer + 2);
     });
+
+    describe('returns round state', () => {
+      it('roundOver', () => {
+        const model = getModel();
+
+        const roundState = model.nextTurn();
+
+        // Expect that we have at least two players, or round is over immediately
+        expect(config.players.length).toBeGreaterThan(1);
+
+        expect(roundState).toBeInstanceOf(Object);
+        expect(roundState).toHaveProperty('roundOver');
+        expect(roundState.roundOver).toBe(false);
+
+        // Advance to the final turn
+        config.players.slice(2).forEach(() => {
+          model.nextTurn();
+        });
+
+        // Complete the final turn, round should be over
+        const roundOverState = model.nextTurn();
+        expect(roundOverState.roundOver).toBe(true);
+      });
+    });
   });
 
   describe('.playWord', () => {

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -173,6 +173,36 @@ describe('Game Model', () => {
         const roundOverState = model.nextTurn();
         expect(roundOverState.roundOver).toBe(true);
       });
+
+      it('winner', () => {
+        const model = getModel();
+
+        const roundState = model.nextTurn();
+
+        // winner should be null if round is not over
+        expect(roundState.roundOver).toBe(false);
+        expect(roundState.winner).toBe(null);
+
+        // Advance to the final turn
+        config.players.slice(2).forEach(() => {
+          model.nextTurn();
+        });
+
+        // Play a word as the last player
+        const word = model.letterBank.slice(0, 5).join('');
+        const score = model.playWord(word);
+
+        // Complete the final turn, round is over and winner should be set
+        const roundOverState = model.nextTurn();
+        expect(roundOverState.roundOver).toBe(true);
+
+        expect(roundOverState.winner).toBeInstanceOf(Object);
+        expect(roundOverState.winner).toMatchObject({
+          word,
+          score,
+          player: config.players[config.players.length - 1],
+        });
+      });
     });
   });
 

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -124,6 +124,53 @@ describe('Game Model', () => {
         expect(letter).toMatch(/^[A-Z]$/);
       });
     });
+
+    describe('returns game state', () => {
+      it('gameOver', () => {
+        const model = new Model({ ...config, rounds: 1 });
+
+        const gameState = model.nextRound();
+
+        expect(gameState).toBeInstanceOf(Object);
+        expect(gameState.gameOver).toBe(false);
+
+        const gameOverState = model.nextRound();
+        expect(gameOverState.gameOver).toBe(true);
+      });
+
+      it('winner', () => {
+        const model = new Model({ ...config, rounds : 2 });
+
+        // Start game, no one has won yet
+        let gameState = model.nextRound();
+        expect(gameState.winner).toBe(null);
+
+        // First player plays a word
+        let p1Score = 0;
+        let word = model.letterBank.slice(0, 5).join('');
+        p1Score += model.playWord(word);
+
+        // Second player does not play
+        model.nextTurn();
+        gameState = model.nextRound();
+        // Game is not over, so no winner yet
+        expect(gameState.winner).toBe(null);
+
+        // First player plays another word
+        word = model.letterBank.slice(0, 5).join('');
+        p1Score += model.playWord(word);
+
+        // Second player does not play again
+        model.nextTurn();
+        gameState = model.nextRound();
+
+        // Game is over now, first player has won
+        expect(gameState.winner).toMatchObject({
+          player: config.players[0],
+          score: p1Score,
+        });
+      });
+    });
   });
 
   describe('.nextTurn', () => {

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -139,6 +139,17 @@ describe('Game Model', () => {
 
       expect(model.nextTurn).toBeDefined();
     });
+
+    it('increments the current player index', () => {
+      const model = getModel();
+      const origPlayer = model.currentPlayer;
+
+      model.nextTurn();
+      expect(model.currentPlayer).toBe(origPlayer + 1);
+
+      model.nextTurn();
+      expect(model.currentPlayer).toBe(origPlayer + 2);
+    });
   });
 
   describe('.playWord', () => {

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -22,5 +22,11 @@ describe('Game Model', () => {
         const model = new Model();
       }).toThrow(/config/);
     });
+
+    it('initializes the round number to zero', () => {
+      const model = new Model(config);
+
+      expect(model.round).toBe(0);
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -77,5 +77,17 @@ describe('Game Model', () => {
 
       expect(model.currentPlayer).toBe(0);
     });
+
+    it('draws a new hand of letters', () => {
+      const model = new Model(config);
+
+      model.nextRound();
+
+      expect(model.letterBank).toBeInstanceOf(Array);
+      expect(model.letterBank).toHaveLength(10);
+      model.letterBank.forEach((letter) => {
+        expect(letter).toMatch(/^[A-Z]$/);
+      });
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -1,0 +1,13 @@
+import Model from 'game/model';
+
+describe('Game Model', () => {
+  const config = {};
+
+  describe('constructor', () => {
+    it('creates a new Model instance', () => {
+      const model = new Model(config);
+
+      expect(model).toBeInstanceOf(Model);
+    });
+  });
+});

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -28,5 +28,16 @@ describe('Game Model', () => {
 
       expect(model.round).toBe(0);
     });
+
+    it('initializes the plays history', () => {
+      const model = new Model(config);
+
+      expect(model.plays).toBeInstanceOf(Object);
+      config.players.forEach((player) => {
+        expect(model.plays).toHaveProperty(player);
+        expect(model.plays[player]).toBeInstanceOf(Array);
+        expect(model.plays[player]).toHaveLength(0);
+      });
+    });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -1,4 +1,5 @@
 import Model from 'game/model';
+import Adagrams from 'game/adagrams';
 
 describe('Game Model', () => {
   const config = {
@@ -103,6 +104,20 @@ describe('Game Model', () => {
       const model = getModel();
 
       expect(model.playWord).toBeDefined();
+    });
+
+    describe('for valid words', () => {
+      const getWord = (model) => {
+        return model.letterBank.slice(0, 5).join('');
+      };
+
+      it('it returns the word score', () => {
+        const model = getModel();
+        const word = getWord(model);
+        const score = Adagrams.scoreWord(word);
+
+        expect(model.playWord(word)).toBe(score);
+      });
     });
   });
 });

--- a/specs/game/model.spec.js
+++ b/specs/game/model.spec.js
@@ -90,4 +90,19 @@ describe('Game Model', () => {
       });
     });
   });
+
+  describe('.playWord', () => {
+    const getModel = () => {
+      const model = new Model(config);
+      model.nextRound();
+
+      return model;
+    };
+
+    it('is defined', () => {
+      const model = getModel();
+
+      expect(model.playWord).toBeDefined();
+    });
+  });
 });

--- a/src/game.js
+++ b/src/game.js
@@ -1,0 +1,7 @@
+import Model from 'game/model';
+import View from 'game/view';
+import Controller from 'game/controller';
+
+// Initialize the controller I guess
+const game = new Controller(Model, View);
+game.start();

--- a/src/game/adagrams.js
+++ b/src/game/adagrams.js
@@ -1,0 +1,44 @@
+import Real from 'adagrams';
+
+const Stub = {
+  drawLetters() {
+    const defaultLetters = ['H', 'E', 'L', 'L', 'O', 'W', 'O', 'R', 'L', 'D'];
+
+    if(typeof Real.drawLetters === 'function') {
+      return Real.drawLetters() || defaultLetters;
+    }
+
+    return defaultLetters;
+  },
+
+  usesAvailableLetters(input, lettersInHand) {
+    if(typeof Real.usesAvailableLetters === 'function') {
+      return Real.usesAvailableLetters(input, lettersInHand);
+    }
+
+    return true;
+  },
+
+  scoreWord(word) {
+    if(typeof Real.scoreWord === 'function') {
+      return Real.scoreWord(word);
+    }
+
+    return -1;
+  },
+
+  highestScoreFrom(words) {
+    if(typeof Real.highestScoreFrom === 'function') {
+      return Real.highestScoreFrom(words);
+    }
+
+    if(words.length < 1) return null;
+
+    return {
+      word: words[0],
+      score: Stub.scoreWord(words[0]),
+    };
+  },
+};
+
+export default Stub;

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -1,0 +1,3 @@
+class Controller {}
+
+export default Controller;

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -21,6 +21,13 @@ class Controller {
 
     // Advance to the first round
     this.game.nextRound();
+    this.startTurn();
+  }
+
+  startTurn() {
+    this.view.playerTurn(this.game, {
+      playWord: this.game.playWord.bind(this.game),
+    });
   }
 
   exit() {

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -3,11 +3,18 @@ class Controller {
     this.model = model;
     this.view = view;
 
-    this.view.init();
+    this.view.init({
+      exit: this.exit.bind(this),
+    });
   }
 
   start() {
     this.view.start();
+  }
+
+  exit() {
+    this.view.exit();
+    process.exit();
   }
 }
 

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -2,6 +2,8 @@ class Controller {
   constructor(model, view) {
     this.model = model;
     this.view = view;
+
+    this.view.init();
   }
 
   start() {

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -20,14 +20,33 @@ class Controller {
     });
 
     // Advance to the first round
-    this.game.nextRound();
-    this.startTurn();
+    this.advanceRound();
+  }
+
+  advanceRound() {
+    const gameState = this.game.nextRound();
+    if(gameState.gameOver) {
+      this.view.gameOver(gameState);
+    } else {
+      this.startTurn();
+    }
   }
 
   startTurn() {
     this.view.playerTurn(this.game, {
       playWord: this.game.playWord.bind(this.game),
+      endTurn: this.endTurn.bind(this),
     });
+  }
+
+  endTurn() {
+    // Advance to next player
+    const roundState = this.game.nextTurn();
+    const callback = (roundState.roundOver
+                       ? this.advanceRound
+                       : this.startTurn).bind(this);
+
+    return { roundState, callback };
   }
 
   exit() {

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -1,3 +1,8 @@
-class Controller {}
+class Controller {
+  constructor(model, view) {
+    this.model = model;
+    this.view = view;
+  }
+}
 
 export default Controller;

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -4,12 +4,17 @@ class Controller {
     this.view = view;
 
     this.view.init({
+      play: this.play.bind(this),
       exit: this.exit.bind(this),
     });
   }
 
   start() {
     this.view.start();
+  }
+
+  play(players, rounds = 3, time = 60) {
+    this.view.play();
   }
 
   exit() {

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -3,6 +3,10 @@ class Controller {
     this.model = model;
     this.view = view;
   }
+
+  start() {
+    this.view.start();
+  }
 }
 
 export default Controller;

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -19,6 +19,8 @@ class Controller {
       players, rounds, time
     });
 
+    this.view.newGame(this.game);
+
     // Advance to the first round
     this.advanceRound();
   }
@@ -28,6 +30,7 @@ class Controller {
     if(gameState.gameOver) {
       this.view.gameOver(gameState);
     } else {
+      this.view.newRound(this.game);
       this.startTurn();
     }
   }

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -14,7 +14,10 @@ class Controller {
   }
 
   play(players, rounds = 3, time = 60) {
-    this.view.play();
+    // Create a new game instance
+    this.game = new this.model({
+      players, rounds, time
+    });
   }
 
   exit() {

--- a/src/game/controller.js
+++ b/src/game/controller.js
@@ -18,6 +18,9 @@ class Controller {
     this.game = new this.model({
       players, rounds, time
     });
+
+    // Advance to the first round
+    this.game.nextRound();
   }
 
   exit() {

--- a/src/game/messages.js
+++ b/src/game/messages.js
@@ -1,5 +1,8 @@
 export default {
   intro: 'Welcome to Adagrams!',
-  play: 'Starting a new game of Adagrams...',
   exit: 'Thank you for playing Adagrams!',
+
+  play: 'Starting a new game of Adagrams...',
+  playWordSuccess: (word, score) => `Played ${word} for ${score} points.`,
+  playWordFailure: (word) => `Invalid word: ${word}.`,
 };

--- a/src/game/messages.js
+++ b/src/game/messages.js
@@ -5,4 +5,6 @@ export default {
   play: 'Starting a new game of Adagrams...',
   playWordSuccess: (word, score) => `Played ${word} for ${score} points.`,
   playWordFailure: (word) => `Invalid word: ${word}.`,
+  roundOver: (winner) => `Round over! The winner of this round is ${winner.player} who got ${winner.word} for ${winner.score} points!`,
+  gameOver: (winner) => `Game over! Our winner is.... ${winner.player} with a total score of ${winner.score}!`,
 };

--- a/src/game/messages.js
+++ b/src/game/messages.js
@@ -2,7 +2,8 @@ export default {
   intro: 'Welcome to Adagrams!',
   exit: 'Thank you for playing Adagrams!',
 
-  play: 'Starting a new game of Adagrams...',
+  newGame: 'Starting a new game of Adagrams...',
+  newRound: (curr, total) => `Round ${curr} of ${total}:`,
   playWordSuccess: (word, score) => `Played ${word} for ${score} points.`,
   playWordFailure: (word) => `Invalid word: ${word}.`,
   roundOver: (winner) => `Round over! The winner of this round is ${winner.player} who got ${winner.word} for ${winner.score} points!`,

--- a/src/game/messages.js
+++ b/src/game/messages.js
@@ -1,0 +1,5 @@
+export default {
+  intro: 'Welcome to Adagrams!',
+  play: 'Starting a new game of Adagrams...',
+  exit: 'Thank you for playing Adagrams!',
+};

--- a/src/game/messages.json
+++ b/src/game/messages.json
@@ -1,5 +1,0 @@
-{
-  "intro": "Welcome to Adagrams!",
-  "play": "Starting a new game of Adagrams...",
-  "exit": "Thank you for playing Adagrams!"
-}

--- a/src/game/messages.json
+++ b/src/game/messages.json
@@ -1,0 +1,3 @@
+{
+  "intro": "Welcome to Adagrams!"
+}

--- a/src/game/messages.json
+++ b/src/game/messages.json
@@ -1,4 +1,5 @@
 {
   "intro": "Welcome to Adagrams!",
+  "play": "Starting a new game of Adagrams...",
   "exit": "Thank you for playing Adagrams!"
 }

--- a/src/game/messages.json
+++ b/src/game/messages.json
@@ -1,3 +1,4 @@
 {
-  "intro": "Welcome to Adagrams!"
+  "intro": "Welcome to Adagrams!",
+  "exit": "Thank you for playing Adagrams!"
 }

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -1,0 +1,3 @@
+class Model {}
+
+export default Model;

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -53,6 +53,7 @@ class Model {
   }
 
   nextTurn() {
+    this.currentPlayer++;
   }
 
   playWord(word) {

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -42,6 +42,7 @@ class Model {
   }
 
   playWord(word) {
+    return Adagrams.scoreWord(word);
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -30,6 +30,7 @@ class Model {
 
   // Start the next round of the game
   nextRound() {
+    this.round++;
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -8,6 +8,7 @@ class Model {
 
     // Initialize game state
     this.round = 0;
+    this.currentPlayer = null;
 
     /* Plays history structure is:
         {

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -52,6 +52,9 @@ class Model {
     });
   }
 
+  nextTurn() {
+  }
+
   playWord(word) {
     if(!this._valid(word)) return null;
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -27,6 +27,10 @@ class Model {
       return plays;
     }, {});
   }
+
+  // Start the next round of the game
+  nextRound() {
+  }
 }
 
 export default Model;

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -40,6 +40,9 @@ class Model {
     // Draw the letter bank
     this.letterBank = Adagrams.drawLetters();
   }
+
+  playWord(word) {
+  }
 }
 
 export default Model;

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -69,6 +69,8 @@ class Model {
   }
 
   playWord(word) {
+    word = word.toUpperCase();
+
     if(!this._valid(word)) return null;
 
     this._recordPlay(word);

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -5,6 +5,9 @@ class Model {
     }
 
     this.config = config;
+
+    // Initialize game state
+    this.round = 0;
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -32,6 +32,12 @@ class Model {
     }, {});
   }
 
+  currentPlayerName() {
+    if(this.currentPlayer === null) return null;
+
+    return this._playerName(this.currentPlayer);
+  }
+
   // Start the next round of the game
   nextRound() {
     this.round++;
@@ -50,6 +56,10 @@ class Model {
   _valid(word, letterBank = this.letterBank) {
     if(word.length < 1) return false;
     return Adagrams.usesAvailableLetters(word, letterBank);
+  }
+
+  _playerName(player) {
+    return this.config.players[player];
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -43,6 +43,11 @@ class Model {
     this.round++;
     this.currentPlayer = 0;
 
+    const gameOver = this.round > this.config.rounds;
+    if(gameOver) {
+      return { gameOver, winner: this._gameWinner() };
+    }
+
     // Draw the letter bank
     this.letterBank = Adagrams.drawLetters();
 
@@ -50,6 +55,8 @@ class Model {
     this.config.players.forEach((player) => {
       this.plays[player][this.round - 1] = [];
     });
+
+    return { gameOver, winner: null };
   }
 
   nextTurn() {
@@ -102,6 +109,29 @@ class Model {
 
     const { word: winningWord } = Adagrams.highestScoreFrom(bestPlays.map(({ word }) => word));
     return bestPlays.find(({ word }) => word === winningWord);
+  }
+
+  _gameWinner() {
+    // Add up the scores for each player, counting only the rounds where they won
+    const roundWinners = [];
+    for(let round = 1; round <= this.config.rounds; round++) {
+      const winner = this._roundWinner(round);
+      const existing = roundWinners.find(({ player }) => player === winner.player);
+
+      if(existing) {
+        existing.score += winner.score;
+      } else {
+        roundWinners.push(winner);
+      }
+    }
+
+    return roundWinners.reduce((gameWinner, roundWinner) => {
+      if(roundWinner.score > gameWinner.score) {
+        gameWinner = roundWinner;
+      }
+
+      return gameWinner;
+    }, { player: '<NOBODY>', score: 0 });
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -1,3 +1,11 @@
-class Model {}
+class Model {
+  constructor(config) {
+    if(!config) {
+      throw new Error('Model requires a config parameter.');
+    }
+
+    this.config = config;
+  }
+}
 
 export default Model;

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -31,6 +31,7 @@ class Model {
   // Start the next round of the game
   nextRound() {
     this.round++;
+    this.currentPlayer = 0;
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -1,3 +1,5 @@
+import Adagrams from 'game/adagrams';
+
 class Model {
   constructor(config) {
     if(!config) {
@@ -34,6 +36,9 @@ class Model {
   nextRound() {
     this.round++;
     this.currentPlayer = 0;
+
+    // Draw the letter bank
+    this.letterBank = Adagrams.drawLetters();
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -42,7 +42,14 @@ class Model {
   }
 
   playWord(word) {
+    if(!this._valid(word)) return null;
+
     return Adagrams.scoreWord(word);
+  }
+
+  _valid(word, letterBank = this.letterBank) {
+    if(word.length < 1) return false;
+    return Adagrams.usesAvailableLetters(word, letterBank);
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -54,6 +54,10 @@ class Model {
 
   nextTurn() {
     this.currentPlayer++;
+
+    return {
+      roundOver: (this.currentPlayer >= this.config.players.length),
+    };
   }
 
   playWord(word) {

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -55,6 +55,8 @@ class Model {
   playWord(word) {
     if(!this._valid(word)) return null;
 
+    this._recordPlay(word);
+
     return Adagrams.scoreWord(word);
   }
 
@@ -65,6 +67,10 @@ class Model {
 
   _playerName(player) {
     return this.config.players[player];
+  }
+
+  _recordPlay(word, player = this.currentPlayer, round = this.round) {
+    this.plays[this._playerName(player)][round - 1].push(word);
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -45,6 +45,11 @@ class Model {
 
     // Draw the letter bank
     this.letterBank = Adagrams.drawLetters();
+
+    // Initialize player history for this round
+    this.config.players.forEach((player) => {
+      this.plays[player][this.round - 1] = [];
+    });
   }
 
   playWord(word) {

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -9,6 +9,7 @@ class Model {
     // Initialize game state
     this.round = 0;
     this.currentPlayer = null;
+    this.letterBank = null;
 
     /* Plays history structure is:
         {

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -8,6 +8,24 @@ class Model {
 
     // Initialize game state
     this.round = 0;
+
+    /* Plays history structure is:
+        {
+          playerOne: [
+            ["APPLE", "PAPA", "LEAP"],    // round 1
+            ["WALK", "WALKER", "RAKE"],   // round 2
+          ],
+
+          playerTwo: [
+            ["PALE", "PELT"],             // round 1
+            ["REAL", "WALTER", "TALKER"], // round 2
+          ],
+        }
+    */
+    this.plays = this.config.players.reduce((plays, player) => {
+      plays[player] = [];
+      return plays;
+    }, {});
   }
 }
 

--- a/src/game/model.js
+++ b/src/game/model.js
@@ -55,9 +55,10 @@ class Model {
   nextTurn() {
     this.currentPlayer++;
 
-    return {
-      roundOver: (this.currentPlayer >= this.config.players.length),
-    };
+    const roundOver = this.currentPlayer >= this.config.players.length;
+    const winner = !roundOver ? null : this._roundWinner(this.round);
+
+    return { roundOver, winner };
   }
 
   playWord(word) {
@@ -79,6 +80,28 @@ class Model {
 
   _recordPlay(word, player = this.currentPlayer, round = this.round) {
     this.plays[this._playerName(player)][round - 1].push(word);
+  }
+
+  _bestPlay(round, player) {
+    const plays = this.plays[player][round - 1];
+    if(plays.length < 1) {
+      return null;
+    }
+
+    return Adagrams.highestScoreFrom(plays);
+  }
+
+  _roundWinner(round) {
+    const bestPlays = this.config.players
+                        .map((player) => ({ player, ...this._bestPlay(round, player) }))
+                        .filter(({ player, word, score }) => word !== undefined);
+
+    if(bestPlays.length < 1) {
+      return { player: '<NOBODY>', word: '<NONE>', score: 0 };
+    }
+
+    const { word: winningWord } = Adagrams.highestScoreFrom(bestPlays.map(({ word }) => word));
+    return bestPlays.find(({ word }) => word === winningWord);
   }
 }
 

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -10,8 +10,31 @@ const View = {
     menu.show();
   },
 
-  play() {
-    menu.log(MESSAGES.play);
+  playerTurn(model, callbacks) {
+    const game = new Vorpal();
+    game
+      .delimiter('')
+      .show();
+
+    game.log(MESSAGES.play);
+    game.log(model.letterBank.join(' '));
+
+    game
+      .mode('playerTurn')
+      .delimiter(`Now playing: ${model.currentPlayerName()}>`)
+      .action((word, done) => {
+        const result = callbacks.playWord(word);
+
+        if(Number.isInteger(result)) {
+          game.log(MESSAGES.playWordSuccess(word, result));
+        } else {
+          game.log(MESSAGES.playWordFailure(word));
+        }
+
+        done();
+      });
+
+    game.exec('playerTurn');
   },
 
   exit() {

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -10,12 +10,31 @@ const View = {
     menu.show();
   },
 
+  play() {
+    menu.log(MESSAGES.play);
+  },
+
   exit() {
     menu.log(MESSAGES.exit);
   },
 
   init(callbacks) {
     menu.delimiter('Adagrams>');
+
+    menu
+      .command('start [players]')
+      .description('Play a game of Adagrams. ')
+      .alias('play', 's', 'p')
+      .option('-r, --rounds <n>', 'Number of rounds')
+      .option('-t, --time <seconds>', 'Time for each round in seconds')
+      .action((args, done) => {
+        const numPlayers = args.players;
+        const rounds = args.options.rounds;
+        const time = args.options.time;
+
+        callbacks.play(numPlayers, rounds, time);
+        done();
+      });
 
     menu
       .find('exit')

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -1,0 +1,3 @@
+const View = {};
+
+export default View;

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -1,7 +1,12 @@
 import Vorpal from 'vorpal';
+import MESSAGES from 'game/messages.json';
 
 const menu = new Vorpal();
 
-const View = {};
+const View = {
+  start(play, exit) {
+    menu.log(MESSAGES.intro);
+  },
+};
 
 export default View;

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -1,3 +1,7 @@
+import Vorpal from 'vorpal';
+
+const menu = new Vorpal();
+
 const View = {};
 
 export default View;

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -1,5 +1,5 @@
 import Vorpal from 'vorpal';
-import MESSAGES from 'game/messages.json';
+import MESSAGES from 'game/messages.js';
 
 const menu = new Vorpal();
 

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -10,8 +10,19 @@ const View = {
     menu.show();
   },
 
-  init() {
+  exit() {
+    menu.log(MESSAGES.exit);
+  },
+
+  init(callbacks) {
     menu.delimiter('Adagrams>');
+
+    menu
+      .find('exit')
+      .action((_, done) => {
+        callbacks.exit();
+        done();
+      });
   },
 };
 

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -32,8 +32,38 @@ const View = {
         const rounds = args.options.rounds;
         const time = args.options.time;
 
-        callbacks.play(numPlayers, rounds, time);
-        done();
+        // Player name selection
+        const validName = (name) => /\w/.test(name.trim());
+
+        let questions;
+        if(!Number.isInteger(numPlayers) || numPlayers < 2) {
+          // Default to a solo game
+          questions = [{
+            name: 'player0',
+            message: 'Player Name: ',
+            validate: validName
+          }];
+        } else {
+          questions = [...Array(numPlayers).keys()].map((n) => ({
+            name: `player${n}`,
+            message: `Player ${n + 1} Name: `,
+            validate: validName
+          }));
+        }
+
+        menu.activeCommand.prompt(questions, (answers) => {
+          const PROP_REGEX = /^player(\d+)$/;
+
+          let playerNames =
+            Object.entries(answers)
+            .map(([prop, val]) => [PROP_REGEX.exec(prop), val.trim()])
+            .filter(([match, val]) => !!match)
+            .sort(([[_, leftNum]], [[__, rightNum]]) => Number(leftNum) - Number(rightNum))
+            .map(([_, name]) => name);
+
+          callbacks.play(playerNames, rounds, time);
+          done();
+        });
       });
 
     menu

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -35,6 +35,24 @@ const View = {
       });
 
     game.exec('playerTurn');
+
+    // Player's turn is over when the mode exits
+    game.on('mode_exit', () => {
+      const {roundState, callback} = callbacks.endTurn();
+      if(roundState.roundOver) {
+        menu.log(MESSAGES.roundOver(roundState.winner));
+        game.hide();
+      }
+
+      // In order to let this turn finish and the Vorpal object to get GC'd
+      // we should enqueue the callback rather than run it now
+      setTimeout(callback, 0);
+    });
+  },
+
+  gameOver(gameState) {
+    menu.log(MESSAGES.gameOver(gameState.winner));
+    menu.show();
   },
 
   exit() {

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -6,6 +6,12 @@ const menu = new Vorpal();
 const View = {
   start(play, exit) {
     menu.log(MESSAGES.intro);
+
+    menu.show();
+  },
+
+  init() {
+    menu.delimiter('Adagrams>');
   },
 };
 

--- a/src/game/view.js
+++ b/src/game/view.js
@@ -10,13 +10,20 @@ const View = {
     menu.show();
   },
 
+  newGame(model) {
+    menu.log(MESSAGES.newGame);
+  },
+
+  newRound(model) {
+    menu.log(MESSAGES.newRound(model.round, model.config.rounds));
+  },
+
   playerTurn(model, callbacks) {
     const game = new Vorpal();
     game
       .delimiter('')
       .show();
 
-    game.log(MESSAGES.play);
     game.log(model.letterBank.join(' '));
 
     game


### PR DESCRIPTION
So I spent some time over the weekend implementing an improved version of the Adagrams "driver code" from the original project.

The result is this CLI game where you can have multiple players try scoring the best anagram from a given hand for a series of rounds.

It's built on top of the actual Adagrams code that students must implement, but I've wrapped that in a stub (`src/game/adagrams.js`) which has some default values in case the methods aren't yet implemented.

The upshot is that students can run the full game throughout the process as they implement each wave, and see the game logic start to work. There is also a test suite for the model code, which can give additional feedback if they've broken something.

To do:
- [x] Update the README to mention the game and instructions for running it
- [x] Add some optionals to README for improving game / fixing bugs (e.g. no duplicate words)
- [x] Fix some simple bugs (e.g. improved message text and case-insensitive input)

Note: If you want to try it out for yourself clone the `solution/obfuscated` branch and do `npm install && npm run game` to start it. Once inside you can use the `start` command to start a solo game, or use `help` for details on options.