### PR TITLE
Update node version to 16.10 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.3.0-alpine3.10
+FROM node:16.10.0-alpine3.14
 
 LABEL maintainer="chris.adadev.org"
 


### PR DESCRIPTION
We go over adding `eslint` and `eslint-plugin-jest` with the students, however the current versions of `eslint-plugin-jest` doesn't support the version of `node` specified in our Dockerfile (which is currently 15.3). This was discovered when students tried to submit their forks of this repo in Learn and their builds failed. Upgrading to the next major version is compatible until it goes EOL in September 2023. This PR updates the Dockerfile to pull `node` 16.10.